### PR TITLE
fix: make cli render option more reasonable

### DIFF
--- a/tools/make_cmdline.js
+++ b/tools/make_cmdline.js
@@ -206,6 +206,7 @@ function cmdlinecode(){
 				if (!outputEndsWithSvg)
 					args['--output'] += '.svg'
 				fs.writeFileSync(args['--output'], svgs[0])
+				console.log(args['--output'])
 			}
 			// multiple pages rendered, output file as `filename.001.svg` etc
 			else {
@@ -213,7 +214,9 @@ function cmdlinecode(){
 					args['--output'] = args['--output'].slice(0, -4) // remove .svg suffix
 
 				for (var i = 0; i < svgs.length; i++) {
-					fs.writeFileSync(args['--output']+"."+i.toString().padStart(3,'0')+".svg", svgs[i])
+					var filename = args['--output']+"."+i.toString().padStart(3,'0')+".svg"
+					fs.writeFileSync(filename, svgs[i])
+					console.log(filename)
 				}
 			}
 		}

--- a/tools/make_cmdline.js
+++ b/tools/make_cmdline.js
@@ -198,8 +198,23 @@ function cmdlinecode(){
 				dispname = p[p.length-1];
 			}
 			var svgs = render(dispname,src,{plotResult:false})
-			for (var i = 0; i < svgs.length; i++){
-				fs.writeFileSync(args['--output']+"."+i.toString().padStart(3,'0')+".svg",svgs[i])
+			
+			var outputEndsWithSvg = args['--output'].toLowerCase().endsWith('.svg');
+
+			// only one page rendered
+			if (svgs.length === 1) {
+				if (!outputEndsWithSvg)
+					args['--output'] += '.svg'
+				fs.writeFileSync(args['--output'], svgs[0])
+			}
+			// multiple pages rendered, output file as `filename.001.svg` etc
+			else {
+				if (outputEndsWithSvg)
+					args['--output'] = args['--output'].slice(0, -4) // remove .svg suffix
+
+				for (var i = 0; i < svgs.length; i++) {
+					fs.writeFileSync(args['--output']+"."+i.toString().padStart(3,'0')+".svg", svgs[i])
+				}
 			}
 		}
 		if (args['--exec']){


### PR DESCRIPTION
This PR modified how cli handles `--render` and `--output` options.

1. For output specified filename ends with `.svg`, will not append `.svg` again.
```bash
$ wenyan ./examples/sieve.wy --render "埃氏篩" --output ./sieve.svg
# Before: sieve.svg.000.svg
# After: sieve.svg
``` 

2. For scripts with one page rendered, the filename will not append with `000` index, and for multiple pages rendered, the `000` index will be inserted before `.svg`

```bash
# Assume we have "sieve.svg" more than one page:
$ wenyan ./examples/sieve.wy --render "埃氏篩" --output ./sieve.svg

# Before: 
#    sieve.svg.000.svg
#    sieve.svg.001.svg

# After:
#    sieve.000.svg
#    sieve.001.svg
``` 

Thanks!