### PR TITLE
chore: add eslint and prettier

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,16 @@
+module.exports = {
+  parserOptions: {
+    ecmaVersion: 2018
+  },  
+  env: {
+    browser: true,
+    node: true,
+    es6: true
+  },
+  extends: [
+    /* disbale rules temporary, before the codebase refactored with module system */
+    // "eslint:recommended",
+    "prettier",
+    "prettier/babel"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -8,10 +8,32 @@
     "make_cmdline": "node ./tools/make_cmdline.js && pkg ./build/wenyan.js --out-path ./build",
     "make_ide": "node ./tools/make_ide.js",
     "make_site": "node ./tools/make_site.js",
-    "test_parser": "node ./tools/test_parser.js"
+    "test_parser": "node ./tools/test_parser.js",
+    "lint:fix": "npm run lint -- --fix",
+    "lint": "eslint {src,tools}/**/*.js",
+    "prettify": "prettier {src,tools}/**/*.js --write"
+  },
+  "husky": {
+    "hooks": {
+      "pre-commit": "lint-staged"
+    }
+  },
+  "lint-staged": {
+    "{src,tools}/**/*.js": [
+      "prettier --write",
+      "eslint --fix",
+      "git add"
+    ]
   },
   "license": "MIT",
   "devDependencies": {
-    "pkg": "^4.4.2"
+    "eslint": "^6.7.2",
+    "eslint-config-prettier": "^6.7.0",
+    "eslint-plugin-babel": "^5.3.0",
+    "eslint-plugin-prettier": "^3.1.2",
+    "husky": "^3.1.0",
+    "lint-staged": "^9.5.0",
+    "pkg": "^4.4.2",
+    "prettier": "^1.19.1"
   }
 }


### PR DESCRIPTION
This addressed to #188

### Changes
- Use `prettier` for formatting, `eslint` for linting
- Use `husky` and `lint-staged` to automatically format and fix before every commit
- There is **no rule** in `eslint` for now. Depends on the code preference you can specify the code standard in `.eslintrc.js`


### Procedure
I did not apply the formatting to any files yet in case there are any conflicts with other PRs. 

If this gets merged, these are steps to format the existing code.

```bash
npm install
npm run prettier
git add .
```

and then commit changes.

After this, you do not need to worry about the formatter any more (Unless when you change the ruleset).

Thanks!
