### PR TITLE
catsrc option only2js, move resetVarCnt to compiler option

### DIFF
--- a/src/asc2py.js
+++ b/src/asc2py.js
@@ -82,11 +82,17 @@ class Ctnr():
 #####
 `
 
-function asc2py(asc){
+function asc2py(asc, _imports, { resetVarCnt } = {}) {
 	var py = pylib;
 	var prevfun="";
 	var curlvl = 0;
 	var strayvar = 0;
+
+  if (resetVarCnt) {
+		tmpVarCnt = 0;
+		randVarCnt = 0;
+	}
+
 	function getval(x){
 		if (x == undefined){
 			return "";

--- a/src/asc2py.js
+++ b/src/asc2py.js
@@ -88,7 +88,7 @@ function asc2py(asc, _imports, { resetVarCnt } = {}) {
 	var curlvl = 0;
 	var strayvar = 0;
 
-  if (resetVarCnt) {
+	if (resetVarCnt) {
 		tmpVarCnt = 0;
 		randVarCnt = 0;
 	}

--- a/src/asc2rb.js
+++ b/src/asc2rb.js
@@ -124,7 +124,7 @@ function lowerAllPinYinAndMakeItGlobal(asc) {
   return asc;
 }
 
-function asc2rb(asc) {
+function asc2rb(asc, _imports, { resetVarCnt } = {}) {
   let rb = rblib;
   let prevfun = "";
   let curlvl = 0;
@@ -132,6 +132,12 @@ function asc2rb(asc) {
   let lambdaList = [];
   let methodIndex = 0;
   asc = lowerAllPinYinAndMakeItGlobal(asc);
+
+  if (resetVarCnt) {
+    tmpVarCount = 0;
+    randVarCount = 0;
+  }
+
   // console.log("START!",asc)
   function getval(x) {
     if (!x) return "";

--- a/src/parser.js
+++ b/src/parser.js
@@ -613,7 +613,7 @@ function tokens2asc(
   return asc;
 }
 
-function asc2js(asc, imports = []) {
+function asc2js(asc, imports = [], { resetVarCnt } = {}) {
   var js = ``; //`"use strict";`;
   var prevfun = "";
   var prevfunpublic = false;
@@ -621,6 +621,11 @@ function asc2js(asc, imports = []) {
   var prevobjpublic = false;
   var curlvl = 0;
   var strayvar = 0;
+
+  if (resetVarCnt) {
+    tmpVarCnt = 0;
+    randVarCnt = 0;
+  }
 
   function getval(x) {
     if (x == undefined) {
@@ -859,10 +864,6 @@ function compile(
     reader = lvl1
   } = {}
 ) {
-  if (resetVarCnt) {
-    tmpVarCnt = 0;
-    randVarCnt = 0;
-  }
   txt = txt.replace(/\r\n/g, "\n");
 
   var tokens = wy2tokens(txt);
@@ -909,23 +910,24 @@ function compile(
   var targ;
   var imports = [];
   var mwrapper;
+  const compilerParams = [asc, imports, { resetVarCnt }];
   switch (lang) {
     case "js":
-      targ = asc2js(asc, imports);
+      targ = asc2js(...compilerParams);
       mwrapper = jsWrapModule;
       break;
     case "py":
       try {
         asc2py = require("./asc2py.js");
       } catch (e) {}
-      targ = asc2py(asc, imports);
+      targ = asc2py(...compilerParams);
       mwrapper = x => x;
       break;
     case "rb":
       try {
         asc2rb = require("./asc2rb.js");
       } catch (e) {}
-      targ = asc2rb(asc, imports);
+      targ = asc2rb(...compilerParams);
       mwrapper = x => x;
       break;
     default:

--- a/tools/make_ide.js
+++ b/tools/make_ide.js
@@ -114,7 +114,7 @@ pre{tab-size: 4;}
 <script src="https://cdnjs.cloudflare.com/ajax/libs/js-beautify/1.10.2/beautify.js"></script>
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.16.2/build/styles/monokai-sublime.min.css">
 <script src="https://cdn.jsdelivr.net/gh/highlightjs/cdn-release@9.16.2/build/highlight.min.js"></script>
-<script>${utils.catsrc()}</script>
+<script>${utils.catsrc({only2js: true})}</script>
 <body style="background:#272822;padding:20px;color:white;font-family:sans-serif;">
 	<h2><i>wenyan-lang</i></h2>
 <table><tr><td><select id="pick-example"></select><button id="run">Run</button>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;<input type="checkbox" id="auto-hl"/><small>Auto Highlight</small></td></tr><tr><td id="in" valign="top"><div class="tbar">EDITOR</div></td><td rowspan="2" valign="top"><div class="tbar">COMPILED JAVASCRIPT</div><pre id="js"></pre></td></tr><tr><td valign="top"><div class="tbar">OUTPUT</div><pre id="out"></pre></td></tr></table>

--- a/tools/utils.js
+++ b/tools/utils.js
@@ -9,20 +9,15 @@ function remotelib(urls) {
   (1, eval)(src);
 }
 
-function catsrc() {
-  var s = "";
-  var srcs = fs.readdirSync("../src/");
-  for (var i = 0; i < srcs.length; i++) {
-    if (srcs[i].endsWith(".js") && !srcs[i].includes("cli")) {
-      s +=
-        fs
-          .readFileSync("../src/" + srcs[i])
-          .toString()
-          .replace(/const/g, "var") + ";\n";
-    }
-  }
-  return s;
-}
+const catsrc = ({ only2js = false } = {}) => fs.readdirSync("../src/")
+  .filter(file => file.endsWith(".js"))
+  .filter(file => !file.includes("cli"))
+  .filter(file => !file.includes("2rb") || !only2js)
+  .filter(file => !file.includes("2py") || !only2js)
+  .map(file => fs.readFileSync("../src/" + file))
+  .map(String)
+  .map(txt => txt.replace(/const/g, "var"))
+  .join(";\n")
 
 function loadlib() {
   var lib = {};


### PR DESCRIPTION
I noticed the `resetVarCnt` from #151 did not work for me now,

It seems like the `tmpVarCount` appears to be variable from `asc2rb.js`, maybe because the function is defined by `const`, or maybe because it is the last `currTmpVar()` appears in script tag

So I add a option `only2js` to `catsrc()` which will stop `asc2rb` and `asc2py` to be inserted in `ide.html`, make the page loads faster and fix the problem.

But I am not really sure if this is a problem only for Safari :D

--------

I also moved the option `resetVarCnt` to all 3 individual compiler (`asc2js`, `asc2py`, `asc2rb`), so option `resetVarCnt` can be used for all of the compilers.