### PR TITLE
chore: unpublish @wenyanlang/highlighter

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,6 +26,6 @@ jobs:
           node-version: 10
           registry-url: https://registry.npmjs.org/
       - run: npm ci
-      - run: npm run publish
+      - run: npm run publish:ci
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "dev": "npm run clear && webpack --mode development --watch",
     "clear": "rimraf ./dist",
     "publish": "bump --commit && node ./tools/publish.js",
+    "publish:ci": "node ./tools/publish.js",
     "release": "bump --commit --tag && git push --follow-tags",
     "make_ide": "node ./tools/make_ide.js",
     "make_site": "node ./tools/make_site.js",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:dev": "npm run clear && webpack --mode development",
     "dev": "npm run clear && webpack --mode development --watch",
     "clear": "rimraf ./dist",
-    "publish": "node ./tools/publish.js",
+    "publish": "bump --commit && node ./tools/publish.js",
     "release": "bump --commit --tag && git push --follow-tags",
     "make_ide": "node ./tools/make_ide.js",
     "make_site": "node ./tools/make_site.js",

--- a/tools/publish.js
+++ b/tools/publish.js
@@ -7,9 +7,14 @@ const root = path.resolve(__dirname, "..");
 const distRoot = path.resolve(__dirname, "../dist");
 const npmOrganization = "@wenyanlang";
 
-const packages = ["cli", "core", "render", "highlighter"];
+const packages = ["cli", "core", "render"];
 
-const fileToCopy = ["README.md", "README-ZH.md", "LICENSE"];
+const fileToCopy = [
+  "README.md",
+  "README-ZH-CN.md",
+  "README-ZH-TW.md",
+  "LICENSE"
+];
 
 const fieldsInPackageJSONToRemove = [
   "devDependencies",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -56,7 +56,6 @@ const Utils = {
   ...Default(),
   entry: {
     render: './src/render.js',
-    highlighter: './src/highlight.js',
   }
 }
 


### PR DESCRIPTION
- Remove build scripts for highlighter since it's no longer needed for site and ide
- Bundles `README-ZH-CN.md` and `README-ZH-TW.md
- Prompt to bump version when running `npm run publish`, as mentioned in #323 

When it gets merged, you can run `npm unpublish @wenyanlang/highlighter -f` to remove it from npm