### PR TITLE
Cli for roman options

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,12 @@ npm install -g @wenyanlang/cli
 Try run the included examples, e.g.:
 
 ```bash
-wenyan examples/helloworld.wy -o helloworld.js
+wenyan examples/helloworld.wy
+# will outputs: 問天地好在。
 ```
+
+> From v0.1.0, the `wenyan` command will direct execute the script by default. If you are migrating from previous versions, please use `wenyan -h` to output the help and check [this PR](https://github.com/LingDong-/wenyan-lang) for the detailed changes.
+
 
 ### [The Online IDE](http://wenyan-lang.lingdong.works/ide.html)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "wenyanlang",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "wenyanlang",
   "description": "文言 A programming language for the ancient Chinese",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "author": "LingDong <lingdong0618@hotmail.com>",
   "private": true,
   "repository": {

--- a/src/cli.js
+++ b/src/cli.js
@@ -34,7 +34,10 @@ program
     "Output compiled code or executing result to file"
   )
   .option("-r, --render", "Outputs renderings")
-  .option("--roman", "Romanize identifiers")
+  .option(
+    "--roman [method]",
+    'Romanize identifiers. The method can be "pinyin", "baxter" or "unicode"'
+  )
   .option("--log <file>", "Save log to file")
   .option("--title <title>", "Override title in rendering")
   .helpOption("-h, --help", "Display help");
@@ -90,6 +93,10 @@ function preprocess() {
     if (program.compile) program.output = `${base}.${program.lang}`;
     else if (program.render) program.output = `${base}.svg`;
     else program.output = `${base}.log`;
+  }
+
+  if (program.roman == true) {
+    program.roman = "pinyin";
   }
 }
 

--- a/src/cli.js
+++ b/src/cli.js
@@ -102,7 +102,6 @@ function preprocess() {
 
 function getCompiled() {
   const source = getSource();
-  console.log(source);
   return compile(program.lang, source, {
     romanizeIdentifiers: program.roman,
     logCallback: logHandler(program.log, "a"),


### PR DESCRIPTION
```diff
 ,_ ,_
 \/ ==
 /\ []

WENYAN LANG 文言 Compiler v0.1.0

Usage: wenyan [options] [files...]

Options:
  -v, --version        Output the version
  -l, --lang <lang>    Target language, can be "js", "py" or "rb" (default:    
                       "js")
  -c, --compile        Output the compiled code instead of executing it        
  -e, --eval <code>    Evaluate script
  -i, --interactive    Interactive REPL
  -o, --output [file]  Output compiled code or executing result to file        
  -r, --render         Outputs renderings
+  --roman [method]     Romanize identifiers. The method can be "pinyin", "baxter" or "unicode"
  --log <file>         Save log to file
  --title <title>      Override title in rendering
  -h, --help           Display help
```

I have also bumped the npm package version. When this gets merged, I will publish a new version `v0.1.0` in order to address recent changes.