### PR TITLE
chore: use the sensible build... compatibly

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,7 +9,7 @@ module.exports = {
   },
   extends: [
     /* disbale rules temporary, before the codebase refactored with module system */
-    // "eslint:recommended",
+    "eslint:recommended",
     "prettier",
     "prettier/babel"
   ]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,17 @@
-all: ide cmdline
-ide:
-	cd tools; node make_ide.js;
-cmdline:
-	cd tools; node make_cmdline.js;
+ALLSRC = $(wildcard lib/*.js) $(wildcard src/*.js)
+ALLTOOL = $(wildcard tools/*.js)
+
+all: ide site
+.PHONY: ide site clean
+
+ide: site/ide.html
+site: site/index.html
+
+site/ide.html: ${ALLSRC} ${ALLTOOL}
+	node tools/make_ide.js;
+
+site/index.html: ${ALLSRC} ${ALLTOOL}
+	node tools/make_site.js > site/index.html;
+
 clean: 
 	rm -f site/ide.html; rm -f build/*

--- a/src/cli.js
+++ b/src/cli.js
@@ -5,7 +5,11 @@ const { render, unrender } = require("./render");
 const path = require("path");
 const commander = require("commander");
 
-var Logo = ` ,_ ,_\n \\/ ==\n /\\ []\n`;
+var Logo = `\
+ ,_ ,_
+ |/ ==
+ /| []
+`.replace(/\|/g, "\\");
 
 const program = new commander.Command();
 program

--- a/src/compiler/base.js
+++ b/src/compiler/base.js
@@ -19,6 +19,4 @@ class BaseCompiler {
   }
 }
 var Base = BaseCompiler;
-try {
-  module.exports = Base;
-} catch (e) {}
+module.exports = BaseCompiler;

--- a/src/compiler/compilers.js
+++ b/src/compiler/compilers.js
@@ -1,14 +1,11 @@
-try {
-  var JS = require("./js");
-  var PY = require("./py");
-  var RB = require("./rb");
-} catch (e) {}
+var JS = require("./js");
+var PY = require("./py");
+var RB = require("./rb");
 const compilers = {
   js: JS,
   py: PY,
   rb: RB
 };
 
-try {
-  module.exports = compilers;
-} catch (e) {}
+module.exports = compilers;
+

--- a/src/compiler/js.js
+++ b/src/compiler/js.js
@@ -1,6 +1,5 @@
-try {
-  var Base = require("./base");
-} catch (e) {}
+var Base = require("./base");
+
 class JSCompiler extends Base {
   compile(options = {}) {
     var imports = options.imports || [];
@@ -303,6 +302,5 @@ class JSCompiler extends Base {
   }
 }
 const JS = JSCompiler;
-try {
-  module.exports = JS;
-} catch (e) {}
+module.exports = JS;
+

--- a/src/compiler/py.js
+++ b/src/compiler/py.js
@@ -1,6 +1,5 @@
-try {
-  var Base = require("./base");
-} catch (e) {}
+var Base = require("./base");
+
 class PYCompiler extends Base {
   compile(options = {}) {
     var imports = options.imports || [];
@@ -331,6 +330,5 @@ class Ctnr():
 `;
 
 const PY = PYCompiler;
-try {
-  module.exports = PY;
-} catch (e) {}
+module.exports = PY;
+

--- a/src/compiler/rb.js
+++ b/src/compiler/rb.js
@@ -1,6 +1,5 @@
-try {
-  var Base = require("./base");
-} catch (e) {}
+var Base = require("./base");
+
 class RBCompiler extends Base {
   rename(name) {
     return name && `${name.toLowerCase()}`;
@@ -381,6 +380,5 @@ require 'forwardable'
 #####
 `;
 const RB = RBCompiler;
-try {
-  module.exports = RB;
-} catch (error) {}
+module.exports = RB;
+

--- a/src/hanzi2num.js
+++ b/src/hanzi2num.js
@@ -258,6 +258,4 @@ function num2hanzi(n, nfrac = 6) {
   }
 }
 
-try {
-  module.exports = { hanzi2num, num2hanzi };
-} catch (e) {}
+module.exports = { hanzi2num, num2hanzi };

--- a/src/hanzi2pinyin.js
+++ b/src/hanzi2pinyin.js
@@ -32806,6 +32806,4 @@ function hanzi2pinyin(a, system = "pinyin") {
   }
   return s;
 }
-try {
-  module.exports = hanzi2pinyin;
-} catch (e) {}
+module.exports = hanzi2pinyin;

--- a/src/highlight.js
+++ b/src/highlight.js
@@ -1,7 +1,5 @@
-try {
-  var { num2hanzi } = require("./hanzi2num");
-  var { NUMBER_KEYWORDS, KEYWORDS } = require("./keywords");
-} catch (e) {}
+var { num2hanzi } = require("./hanzi2num");
+var { NUMBER_KEYWORDS, KEYWORDS } = require("./keywords");
 
 var DEFAULT_COLORS = {
   ctrl: "#F92672",

--- a/src/keywords.js
+++ b/src/keywords.js
@@ -112,6 +112,4 @@ if (!Object.fromEntries) {
 }
 var KEYWORDS = Object.fromEntries(ke);
 
-try {
-  module.exports = { NUMBER_KEYWORDS, KEYWORDS };
-} catch (e) {}
+module.exports = { NUMBER_KEYWORDS, KEYWORDS };

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,11 +1,9 @@
-try {
-  var { hanzi2num, num2hanzi } = require("./hanzi2num");
-  var hanzi2pinyin = require("./hanzi2pinyin");
-  var STDLIB = require("./stdlib");
-  var { NUMBER_KEYWORDS, KEYWORDS } = require("./keywords");
-  var version = require("./version");
-  var compilers = require("./compiler/compilers");
-} catch (e) {}
+var { hanzi2num, num2hanzi } = require("./hanzi2num");
+var hanzi2pinyin = require("./hanzi2pinyin");
+var STDLIB = require("./stdlib");
+var { NUMBER_KEYWORDS, KEYWORDS } = require("./keywords");
+var version = require("./version");
+var compilers = require("./compiler/compilers");
 
 function wy2tokens(txt) {
   var tokens = [];
@@ -714,6 +712,10 @@ function compile(
   return targ;
 }
 
+if (typeof version === 'undefined') {
+  let version = 'web-unknown';
+}
+
 var parser = {
   compile,
   version,
@@ -726,6 +728,4 @@ var parser = {
   NUMBER_KEYWORDS,
   STDLIB
 };
-try {
-  module.exports = parser;
-} catch (e) {}
+module.exports = parser;

--- a/src/render.js
+++ b/src/render.js
@@ -1,9 +1,7 @@
-try {
-  var fs = require("fs");
-  var { semantic } = require("./highlight");
-  var { num2hanzi } = require("./hanzi2num");
-  var parser = require("./parser");
-} catch (e) {}
+var fs = require("fs");
+var { semantic } = require("./highlight");
+var { num2hanzi } = require("./hanzi2num");
+var parser = require("./parser");
 
 const FONT = "'I.Ming', 'Source Han Serif KR', 'Noto Serif CJK KR', serif"; //"Source Han Serif TC"
 const RED = "#E53";

--- a/src/stdlib.js
+++ b/src/stdlib.js
@@ -1,22 +1,22 @@
+function loadStdlib() {
+  const STDLIB = {};
+
+  const raw = require.context("../lib", true, /.*\.wy$/);
+
+  raw.keys().forEach(key => {
+    const parts = key.slice(2, -3).split("/");
+    const data = raw(key).default;
+    let lib = STDLIB;
+    for (const part of parts.slice(0, -1)) {
+      if (!lib[part]) lib[part] = {};
+      lib = lib[part];
+    }
+    lib[parts[parts.length - 1]] = data;
+  });
+
+  return STDLIB;
+}
+
 try {
-  function loadStdlib() {
-    const STDLIB = {};
-
-    const raw = require.context("../lib", true, /.*\.wy$/);
-
-    raw.keys().forEach(key => {
-      const parts = key.slice(2, -3).split("/");
-      const data = raw(key).default;
-      let lib = STDLIB;
-      for (const part of parts.slice(0, -1)) {
-        if (!lib[part]) lib[part] = {};
-        lib = lib[part];
-      }
-      lib[parts[parts.length - 1]] = data;
-    });
-
-    return STDLIB;
-  }
-
   module.exports = loadStdlib();
 } catch (e) {}

--- a/src/version.js
+++ b/src/version.js
@@ -1,5 +1,8 @@
 try {
-  const package = require("../package.json");
+  var package = require("../package.json");
+} catch (e) {
+  var package = { version: 'Unknown' };
+}
 
-  module.exports = package.version;
-} catch (e) {}
+module.exports = package.version;
+

--- a/test/.eslintrc.json
+++ b/test/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+  "env": {
+    "mocha": true,
+    "node": true,
+    "es6": true
+  }
+}

--- a/tools/make_ide.js
+++ b/tools/make_ide.js
@@ -1,6 +1,4 @@
-try {
-  process.chdir("./tools");
-} catch (e) {} //make sure we're in tools directory
+process.chdir(__dirname); //make sure we're in tools directory
 
 var fs = require("fs");
 var execSync = require("child_process").execSync;

--- a/tools/make_site.js
+++ b/tools/make_site.js
@@ -1,6 +1,4 @@
-try {
-  process.chdir("./tools");
-} catch (e) {} //make sure we're in tools directory
+process.chdir(__dirname); //make sure we're in tools directory
 
 const fs = require("fs");
 const utils = require("./utils");
@@ -148,7 +146,7 @@ pre{
 #bg{
   width: 100%;
   height: 400px;
-  // overflow: scroll;
+  /*overflow: scroll;*/
   overflow: hidden;
   position: absolute;
   left: 0px;

--- a/tools/test_parser.js
+++ b/tools/test_parser.js
@@ -1,6 +1,4 @@
-try {
-  process.chdir("./tools");
-} catch (e) {}
+process.chdir(__dirname); //make sure we're in tools directory
 
 var fs = require("fs");
 var parser = require("../src/parser");

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,7 @@ const Default = () => {
   return {
     devtool: 'source-map',
     output: {
-      globalObject: '(typeof self !== "undefined" ? self : this)', // make it works for both node and browser
+      globalObject: 'globalThis', // make it works for both node and browser
       libraryTarget: 'umd2',
       library: ["Wenyan", "[name]"],
       path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
We try to use the "sensible" build when possible, handling all the old
try/catch magic in catsrc. This mostly works, except for a problem in
the parser that appears to be also present in my previous version: a
huge object tries to reference things that don't exist.

[The site is unchanged for now to avoid breaking any new things.
Somebody added a // comment to CSS which is invalid, so expect it to not
work. I did not break it.]

The eslint rules are enabled. They don't really hit any package problems
any more, so I figure it's time to turn them on. I added an rc for the
tests so every complaint left is a true positive now. **FIxing them? not
my job.**

The Makefile has been rewritten to be aware of new changes. In the long
run webpack would be the way to go still.