### PR TITLE
fix: 書之 prints "true", "false" instead of "陽", "陰"

### DIFF
--- a/src/hanzi2num.js
+++ b/src/hanzi2num.js
@@ -849,6 +849,13 @@ function num2hanzi(n, format = "", precision = undefined) {
   return str;
 }
 
+function bool2hanzi(b) {
+  if (b) {
+    return "陽";
+  }
+  return "陰";
+}
+
 try {
-  module.exports = { hanzi2num, hanzi2numstr, num2hanzi };
+  module.exports = { hanzi2num, hanzi2numstr, num2hanzi, bool2hanzi };
 } catch (e) {}

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,5 +1,5 @@
 try {
-  var { hanzi2num, hanzi2numstr, num2hanzi } = require("./hanzi2num");
+  var { hanzi2num, hanzi2numstr, num2hanzi, bool2hanzi } = require("./hanzi2num");
   var hanzi2pinyin = require("./hanzi2pinyin");
   var STDLIB = require("./stdlib");
   var { NUMBER_KEYWORDS, KEYWORDS } = require("./keywords");
@@ -761,6 +761,7 @@ var parser = {
   hanzi2num,
   hanzi2numstr,
   num2hanzi,
+  bool2hanzi,
   hanzi2pinyin,
   KEYWORDS,
   NUMBER_KEYWORDS,

--- a/tools/make_ide.js
+++ b/tools/make_ide.js
@@ -166,6 +166,8 @@ function main() {
     for (var i = 0; i < arguments.length; i++) {
       if (typeof arguments[i] == "number") {
         outdiv.innerText += num2hanzi(arguments[i]);
+      } else if (typeof arguments[i] == "boolean") {
+        outdiv.innerText += bool2hanzi(arguments[i]);
       } else {
         outdiv.innerText += arguments[i];
       }

--- a/tools/make_site.js
+++ b/tools/make_site.js
@@ -87,6 +87,8 @@ function main() {
     for (var i = 1; i < arguments.length; i++) {
       if (typeof arguments[i] == "number") {
         outdiv.innerText += num2hanzi(arguments[i]);
+      } else if (typeof arguments[i] == "boolean") {
+        outdiv.innerText += bool2hanzi(arguments[i]);
       } else {
         outdiv.innerText += arguments[i];
       }


### PR DESCRIPTION
Refer to the third and the fourth result in [歐幾里得法](http://wenyan-lang.lingdong.works/ide.html?example=euclidean).

I'm not sure whether my changes work, as I haven't got npm installed on my computer. Sorry for the inconvenience.